### PR TITLE
添加单图位置固定布局示例。

### DIFF
--- a/SZTUthesis.cls
+++ b/SZTUthesis.cls
@@ -95,6 +95,8 @@ Just choose `xelatex', no `pdflatex' or `latex' and so on.}
 \RequirePackage{chngcntr}
 % 字符串处理
 \RequirePackage{xstring}
+% 添加浮动环境
+\RequirePackage{float}
 
 % 参考文献格式 GBT7714-2005
 % 来自https://github.com/CTeX-org/gbt7714-bibtex-style

--- a/content/content.tex
+++ b/content/content.tex
@@ -81,6 +81,16 @@
 \label{F.sztu_single}
 \end{figure}
 
+\subsection{单图位置固定布局示例}
+在LaTeX中，figure环境用于插入和管理图片或图表，而放置图片的方式由可选参数来控制。H是一个浮动参数选项，表示强制将图片放置在其出现的位置。具体来说，H是由float包提供的选项，如果要使用它，需要在导言区加载float包：
+\begin{figure}[H]
+    \centering
+    \includegraphics[width=0.5\linewidth]{sztu.png}
+    \caption{图片位置固定布局示例}
+    \label{fig:H_example}
+\end{figure}
+这样做会强制LaTeX将图片放在代码中的确切位置，而不会尝试将其移动到其他页面或位置。这个选项对于需要严格控制图片位置的文档特别有用。在这个示例中，figure环境中的图片会在其代码位置处被强制放置，而不会被浮动到文档的其他地方。
+
 \subsection{横排布局}
 
 \emph{横排布局如图~\ref{F.sztu_row} 所示。}


### PR DESCRIPTION
原本的模板中图片示例都是浮动布局类型的，使用起来会有些不便，所以加入位置固定的布局示例。
使用H可以将图片的位置固定，而不会浮动，它的好处在于强制 LaTeX 将图片放在代码中的确切位置，而不会尝试将其移动到其他页面或位置。这个选项对于需要严格控制图片位置的文档特别有用。如下图所示，图片会指定出现在文本确定的位置范围，既在latex代码中图片在两段文字中间，那就不会在输出文件图片浮动（下一段话移动到图片上来）的情况。
![image](https://github.com/SZTU-ACM/SZTU-Thesis-Latex-Template/assets/88485359/81d4f02e-4096-4b68-a60c-70e21bb6fb1b)
![image](https://github.com/SZTU-ACM/SZTU-Thesis-Latex-Template/assets/88485359/b9097e36-268a-4a9f-bf28-106a4fb6cd24)
![image](https://github.com/SZTU-ACM/SZTU-Thesis-Latex-Template/assets/88485359/c150a44b-098c-4e0e-950c-2a6877c29fb1)
